### PR TITLE
README: leave `.cr` out when requiring as a shard

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dependencies:
 
 
 ```crystal
-require "docopt.cr"
+require "docopt"
 describe "Docopt" do
   # TODO: Write tests
 


### PR DESCRIPTION
As per [documentation](https://crystal-lang.org/docs/syntax_and_semantics/requiring_files.html), `require` should leave the `.cr` out if we want the lookup to find the `docopt/docopt.cr` in CRYTAL_PATH. 

Confirmed on a new freshly installed version of crystal/shards (0.19.4): error with the previous README, correctly working with this fix.